### PR TITLE
fixed "main" property of bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "notie",
   "description": "notie - a clean and simple notification suite for javascript, with no dependencies",
-  "main": "notie.js",
+  "main": [
+      "dist/notie.js",
+      "dist/notie.css"
+  ],
   "authors": [
     "Jared Reich"
   ],


### PR DESCRIPTION
Since the latest update wirdep did not include notie.css for me because it was missing in the bower.json.