### PR TITLE
Fix bug with `activeElement` being `null`

### DIFF
--- a/notie.js
+++ b/notie.js
@@ -700,7 +700,7 @@ var notie = function() {
 	}
 	
 	function blur() {
-		document.activeElement.blur();
+		document.activeElement && document.activeElement.blur();
 	}
 	
 	var originalBodyHeight, originalBodyOverflow;


### PR DESCRIPTION
[`document.activeElement` is sometimes `null`](https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement). This commit adds a safeguard against calling `blur` on `activeElement` when it's falsy.
